### PR TITLE
String template support

### DIFF
--- a/calc.css
+++ b/calc.css
@@ -1,6 +1,6 @@
 body {
   font-family: "Droid Sans Mono", Courier;
-  max-width: 700px;
+  max-width: 80%;
   margin: 0 auto;
 }
 p,
@@ -10,12 +10,12 @@ h1 {
 .left {
   display: inline-block;
   box-sizing: border-box;
-  width: 70%;
+  width: 60%;
 }
 .right {
   display: inline-block;
   box-sizing: border-box;
-  width: 30%;
+  width: 40%;
   vertical-align: top;
 }
 #inputArea {

--- a/calc.js
+++ b/calc.js
@@ -37,7 +37,14 @@ $(document).ready(function () { import('https://cdnjs.cloudflare.com/ajax/libs/m
     "1000 sqyard in hectares\n" +
     "5000 watts to hp\n" +
     "30 BTU in Wh\n" +
-    "3 decades in minutes";
+    "3 decades in minutes\n" +
+    "\n" +
+    "\n" +
+    "Templates\n" +
+    "---------\n" + 
+    "\n" +
+    '"Since the price of eggs is {{costPerEgg}}, and there are {{eggsPerCarton}} eggs in each carton"\n' +
+    '"and since there are {{numberOfCartons}} cartons, the total cost is {{totalCost}}"';
 
   var $inputArea = $("#inputArea"),
     $outputArea = $("#outputArea");

--- a/calc.js
+++ b/calc.js
@@ -1,6 +1,6 @@
 // Note: can't use "strict mode" since we need to eval() non-strict code from the user
 
-$(document).ready(function () {
+$(document).ready(function () { import('https://cdnjs.cloudflare.com/ajax/libs/mustache.js/4.2.0/mustache.min.js').then((Mustache) => {
   var $ = window.$;
 
   var exampleCalculation =
@@ -43,6 +43,8 @@ $(document).ready(function () {
     $outputArea = $("#outputArea");
 
   var binaryOperators = /^[\+\-\*\/]/;
+  // This is not a full-blown JSON string match; if the string turns out not to be a valid string it will be picked up at parse time
+  var templateString = /^\s*".*"\s*$/;
 
   var previousAnswerLines = []; // keep copy of old answers to see what changed
 
@@ -74,6 +76,18 @@ $(document).ready(function () {
           ) {
             line = "ans " + line;
           }
+          if (templateString.test(line)) {
+            var templateMatch = line.match(templateString);
+            try {
+              var templateSrc = JSON.parse(templateMatch);
+            } catch(err) {
+              outputLines[i] = null;
+              return;
+            }
+            var renderedTemplate = Mustache.default.render(templateSrc, context);
+            outputLines[i] = renderedTemplate;
+            return;
+          }
 
           var answer = math.evaluate(line, context);
 
@@ -97,6 +111,8 @@ $(document).ready(function () {
       var row;
       if (line instanceof math.Unit || typeof line === "number") {
         row = math.format(line, 4);
+      } else if (typeof line == 'string') {
+        row = line;
       } else {
         row = "&nbsp;";
       }
@@ -170,4 +186,4 @@ $(document).ready(function () {
 
     printInitialLines();
   }
-});
+})});

--- a/calc.js
+++ b/calc.js
@@ -45,7 +45,12 @@ $(document).ready(function () { import('https://cdnjs.cloudflare.com/ajax/libs/m
     "\n" +
     "extraEggs = 2\n" +
     '"If we added an extra {{extraEggs}} eggs to each carton"\n' +
-    '"The cartons would now cost {{(eggsPerCarton+extraEggs)*costPerEgg}} each"';
+    '"The cartons would now cost {{(eggsPerCarton+extraEggs)*costPerEgg}} each"\n' +
+    "speed = 5\n" +
+    '"""\n' +
+    'Running a marathon at {{speed}} min/km will take {{42.195*speed}} minutes.\n' +
+    'This is equivalent to {{60/speed}} km/h\n' +
+    '"""\n';
 
   var $inputArea = $("#inputArea"),
     $outputArea = $("#outputArea");

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.5.0/math.js" integrity="sha512-PRRHSwgn8QJinp43y5B698YK/FApqSvwmd7kVu8NWMksCl/3daKnNbPNWPuGKDrpIIb+0Dg5W55VSbZi0QG60Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js" integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- this is actually imported directly from calc.js -->
+    <!-- script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/4.2.0/mustache.min.js" type="module" integrity="sha512-CswfmQmJj8DXhm29Qc5eLk5//2EW1CaI6de+RmRhSrWrXRhkBQ3795tuwJvT6DK6EF4IVqJIRmBg8EokL6c87g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script -->
     <script src="calc.js"></script>
 
     <link href='https://fonts.googleapis.com/css?family=Droid+Sans+Mono' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
This adds the ability to use string templates to generate text incorporating variables and calculations
The string templates are quoted - either singly on an individual line, or with triple quotes over multiple lines
The mustache template syntax is used (basically just `{{expression}}`; the more advanced functions like sections aren't relevant)
mathjs expressions are supported within the template expressions.

Not sure if this would be of interest, or if you think this syntax the best
I've found it useful with calculating things and then generating messages explaining them
(I also adjusted the styling to be able to produce wider output)